### PR TITLE
Bump solc and pin CI actions to specific SHAs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,6 +48,18 @@ jobs:
         run: |
           uv sync --frozen --no-install-project
           npm ci
+      - name: Install Solidity compiler
+        run: |
+          set -euo pipefail
+          solcx_dir="$HOME/.solcx"
+          temp_dir="$(mktemp -d)"
+          compiler_path="$temp_dir/solc-static-linux"
+          compiler_url="https://github.com/ethereum/solidity/releases/download/v0.8.34/solc-static-linux"
+          compiler_sha256="d40adc6f9fdbb22a97d32a02fa05688bf2ee7886affc48c9851b0afd4a726b39"
+          mkdir -p "$solcx_dir"
+          curl -fsSL "$compiler_url" -o "$compiler_path"
+          echo "$compiler_sha256 $compiler_path" | sha256sum --check --status
+          install -m 0755 "$compiler_path" "$solcx_dir/solc-v0.8.34"
       - name: Import Brownie network settings
         run: uv run brownie networks import data/networks.yml true
       - name: Compile contracts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,13 +8,13 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Set up uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true
       - name: Install dependencies
@@ -31,17 +31,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Set up uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true
       - name: Set up Foundry
-        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10
+        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
         with:
           version: stable
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A prototype implementation of escrow information concealment using Joux's Tripar
   - bls12_381 curve operations
 - [Solidity](https://docs.soliditylang.org/)
   - We are using Solidity to implement our smart contracts. 
-  - Currently, we are using v0.8.23.
+  - Currently, we are using v0.8.34.
 - [eth-brownie](https://github.com/eth-brownie/brownie)
   - We are using the eth-brownie framework for developing and testing our contracts.
 - [Anvil](https://www.getfoundry.sh/anvil)

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -8,6 +8,6 @@ networks:
 compiler:
     evm_version: berlin
     solc:
-        version: 0.8.23
+        version: 0.8.34
 dependencies:
     OpenZeppelin/openzeppelin-contracts@4.9.3

--- a/contracts/access/Ownable.sol
+++ b/contracts/access/Ownable.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 import "../utils/Errors.sol";
 

--- a/contracts/exchange/DVPStorage.sol
+++ b/contracts/exchange/DVPStorage.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 import "../access/Ownable.sol";
 import "../utils/Errors.sol";

--- a/contracts/exchange/IbetSecurityTokenDVP.sol
+++ b/contracts/exchange/IbetSecurityTokenDVP.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "./DVPStorage.sol";

--- a/contracts/ledger/PersonalInfo.sol
+++ b/contracts/ledger/PersonalInfo.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 import "../utils/Errors.sol";
 

--- a/contracts/token/IbetShare.sol
+++ b/contracts/token/IbetShare.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "../access/Ownable.sol";

--- a/contracts/token/IbetStandardToken.sol
+++ b/contracts/token/IbetStandardToken.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "../access/Ownable.sol";

--- a/contracts/token/IbetStraightBond.sol
+++ b/contracts/token/IbetStraightBond.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 import "OpenZeppelin/openzeppelin-contracts@4.9.3/contracts/utils/math/SafeMath.sol";
 import "../access/Ownable.sol";

--- a/contracts/utils/Errors.sol
+++ b/contracts/utils/Errors.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 library ErrorCode {
     // 10XXXX

--- a/contracts/utils/TripartiteKeyExchange.sol
+++ b/contracts/utils/TripartiteKeyExchange.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 /// @title Joux's tripartite diffie-hellmann key exchange
 contract TripartiteKeyExchange {

--- a/interfaces/ContractReceiver.sol
+++ b/interfaces/ContractReceiver.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 interface ContractReceiver {
     function tokenFallback(

--- a/interfaces/IbetExchangeInterface.sol
+++ b/interfaces/IbetExchangeInterface.sol
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 import "./ContractReceiver.sol";
 

--- a/interfaces/IbetSecurityTokenInterface.sol
+++ b/interfaces/IbetSecurityTokenInterface.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 import "./IbetStandardTokenInterface.sol";
 

--- a/interfaces/IbetStandardTokenInterface.sol
+++ b/interfaces/IbetStandardTokenInterface.sol
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.34;
 
 /// @title ibet Standard Token Interface
 abstract contract IbetStandardTokenInterface {


### PR DESCRIPTION
## 📌 Description

<!-- Please provide a clear and concise description of the changes. -->

This pull request updates the Solidity compiler version from 0.8.23/0.8.0 to 0.8.34 across all smart contracts, interfaces, and configuration files.
It also updates the GitHub Actions workflow configuration to use specific commit SHAs and associated version comments for all third-party action dependencies. 

## ✅ Related Issues

<!-- Link to related issues using "Fixes #issue_number" or "Closes #issue_number". -->
None

## 🔄 Changes

<!-- List the major changes in this PR. -->

**Solidity Version Upgrade:**

* Updated the pragma statement to `^0.8.34` in all Solidity source files, including contracts and interfaces, to ensure the project uses the latest supported compiler version. 
* Updated `brownie-config.yaml` to set the Solidity compiler version to 0.8.34.

**Continuous Integration and Build Process:**

* Updated the GitHub Actions workflow (`.github/workflows/pr.yml`) to pin all used actions to specific commit hashes for improved security and reproducibility, and added a step to install the Solidity 0.8.34 compiler with checksum verification. 

## 📌 Checklist

- [x] I have added tests where necessary.
- [x] I have updated the documentation where necessary.
